### PR TITLE
Create rankings saving table plus multiple championship for same season

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -16,9 +16,22 @@ class EditionsController < ApplicationController
     @edition = Edition.find(params[:id])
   end
 
+  def edit
+    @edition = Edition.find(params[:id])
+  end
+
+  def update
+    @edition = Edition.find(params[:id])
+    if @edition.update(edition_params)
+      redirect_to editions_path
+    else
+      render :edit
+    end
+  end
+
   private
 
   def edition_params
-    params.require(:edition).permit(:season_id, :competition_id)
+    params.require(:edition).permit(:season_id, :competition_id, :designation, :second_leg)
   end
 end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -32,6 +32,6 @@ class EditionsController < ApplicationController
   private
 
   def edition_params
-    params.require(:edition).permit(:season_id, :competition_id, :designation, :second_leg)
+    params.require(:edition).permit(:season_id, :competition_id, :designation, :letter, :second_leg)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,14 +18,12 @@ class PagesController < ApplicationController
     # See later the possibility to get season_years into path macaboime.fr/2020-2021
 
     season_years = params[:season_years] || SeasonsHelper::CurrentSeasonYears.get
-    season = Season.find_by(years: season_years)
+    @season = Season.find_by(years: season_years)
     competition = Competition.where(kind: "championship")
-    @edition = Edition.find_by(season: season, competition: competition)
-    @articles = season.articles.order(id: :desc) if season
-
-    @ranking_datas = Competitions::Championship.new(edition: @edition).ranking_datas
+    @editions = Edition.where(season: @season, competition: competition)
+    @articles = @season.articles.order(id: :desc) if @season
 
     # select all schedules (all competition kinds) from the same season of that @schedule
-    @season_schedules = Schedule.where(edition_id: Edition.where(season: @edition.season)).order(:id) if @edition
+    @season_schedules = Schedule.where(edition_id: Edition.where(season: @season)).order(:id) if @editions.present?
   end
 end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -24,6 +24,21 @@ class ResultsController < ApplicationController
   end
 
   def update_results
+    Schedule.transaction do
+      @schedule = Schedule.find(params[:schedule_id])
+      
+      if @schedule.update(schedule_params)
+        # Vérifier si des results ont été modifiés
+        save_new_ranking_data
+        
+        redirect_to enter_results_path(@schedule), notice: "Schedule #{@schedule.designation} has been updated!"
+      else
+        render :edit
+      end
+    end
+  end
+
+  def update_results_OLD
     @schedule = Schedule.find(params[:schedule_id])
     if @schedule.update(schedule_params)
       redirect_to enter_results_path(@schedule), notice: "Schedule #{@schedule.designation} has been updated!"
@@ -52,5 +67,15 @@ class ResultsController < ApplicationController
               ]
             ]
           )
+  end
+
+  def save_new_ranking_data
+    logger.info "$$$$$$$ Handle result update $$$$$$$$"
+
+    # TODO TOCHECK : does result_changed? is enought to catch nested attributes ?
+    @schedule.edition.rankings.create!(
+      data: Competitions::Championship.new(edition: @schedule.edition).ranking_datas
+    )
+
   end
 end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -33,7 +33,7 @@ class SchedulesController < ApplicationController
       if @schedule.save
         i += 1
         # then create next ones (date + 7 days) btw 2 schedules
-        while i <= ((@edition.teams.count - 1 + (@edition.teams.count % 2)) * 2)
+        while i <= ((@edition.teams.count - 1 + (@edition.teams.count % 2)) * (@edition.second_leg? ? 2 : 1))
           # create new schedule 7 days later
           Schedule.create(
             edition: @edition,
@@ -64,16 +64,18 @@ class SchedulesController < ApplicationController
       end
       schedule = schedule.next
     end
-    second_legs_games = first_legs_games.shuffle
-    second_legs_games.each do |day|
-      day.each do |game|
-        if game.compact.count == 2
-          new_game = Game.create(schedule: schedule)
-          Result.create(game: new_game, team: game.last)
-          Result.create(game: new_game, team: game.first)
+    if @edition.second_leg?
+      second_legs_games = first_legs_games.shuffle
+      second_legs_games.each do |day|
+        day.each do |game|
+          if game.compact.count == 2
+            new_game = Game.create(schedule: schedule)
+            Result.create(game: new_game, team: game.last)
+            Result.create(game: new_game, team: game.first)
+          end
         end
+        schedule = schedule.next
       end
-      schedule = schedule.next
     end
 
   end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -28,17 +28,20 @@ class SchedulesController < ApplicationController
     # if first day schedule (send through form) is in the futur
     if (@schedule.day > current_date)
       # then save 1st schedule
-      @schedule.designation = "J" + sprintf("%02d",i)
+      @schedule.designation = (@edition.letter || "J") + sprintf("%02d",i)
       @schedule.edition = @edition
       if @schedule.save
+        previous_schedule = @schedule
         i += 1
         # then create next ones (date + 7 days) btw 2 schedules
         while i <= ((@edition.teams.count - 1 + (@edition.teams.count % 2)) * (@edition.second_leg? ? 2 : 1))
           # create new schedule 7 days later
-          Schedule.create(
+          new_schedule = Schedule.create(
             edition: @edition,
-            day: Schedule.all.last.day + 7,
-            designation: "J" + sprintf("%02d",i))
+            day: previous_schedule.day + 7,
+            designation: (@edition.letter || "J") + sprintf("%02d",i)
+          )
+          previous_schedule = new_schedule
           # increment round number
           i += 1
         end
@@ -62,8 +65,9 @@ class SchedulesController < ApplicationController
           Result.create(game: new_game, team: game.last)
         end
       end
-      schedule = schedule.next
+      schedule = schedule.next_in_edition
     end
+    
     if @edition.second_leg?
       second_legs_games = first_legs_games.shuffle
       second_legs_games.each do |day|
@@ -74,7 +78,7 @@ class SchedulesController < ApplicationController
             Result.create(game: new_game, team: game.first)
           end
         end
-        schedule = schedule.next
+        schedule = schedule.next_in_edition
       end
     end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -6,7 +6,8 @@ class Edition < ApplicationRecord
   has_many :schedules
   has_many :articles
 
-  validates :competition_id, uniqueness: { scope: :season_id }
+  validates :designation, presence: true
+  validates :competition_id, uniqueness: { scope: [:season_id, :designation] }
 
   def label_for_select
     "#{self.season.years}/#{self.competition.kind}/#{self.competition.name}"

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -5,11 +5,26 @@ class Edition < ApplicationRecord
   has_many :teams, through: :contestants
   has_many :schedules
   has_many :articles
+  has_many :rankings
 
   validates :designation, presence: true
   validates :competition_id, uniqueness: { scope: [:season_id, :designation] }
 
   def label_for_select
     "#{self.season.years}/#{self.competition.kind}/#{self.competition.name}"
+  end
+
+  def ranking
+    rankings.where(initial: false).last
+  end
+
+  def ranking_initial
+    rankings.where(initial: true).last
+  end
+
+  def computed_ranking_datas
+    # TODO : ranking_data should compute last ranking data and last ranking_initial data
+    # ranking_datas = @edition.rankings.any? ? @edition.ranking.data : Competitions::Championship.new(edition: @edition).ranking_datas
+    Competitions::Championship.new(edition: self).ranking_datas
   end
 end

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -1,4 +1,4 @@
 class Ranking < ApplicationRecord
   belongs_to :edition
-  serialize :data, Hash
+  # serialize :data, Hash => Ruby already do that by default on json type column
 end

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -1,0 +1,4 @@
+class Ranking < ApplicationRecord
+  belongs_to :edition
+  serialize :data, Hash
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -11,22 +11,27 @@ class Schedule < ApplicationRecord
 
 
   def next
-    next_schedule = self.class.where("day > ?", self.class.find(id).day).first
+    next_schedule = self.class.where("day > ?", self.day).first
     self.edition == next_schedule&.edition ? next_schedule : nil
   end
 
   def next_in_season
-    next_schedule = self.class.where("day > ?", self.class.find(id).day).first
+    next_schedule = self.class.where("day >= ? AND created_at > ?", self.day, self.created_at).order(:day).first
+    self.season == next_schedule&.season ? next_schedule : nil
+  end
+
+  def next_in_edition
+    next_schedule = self.class.where("day > ? AND edition_id = ?", self.day, self.edition_id).order(:day).first
     self.season == next_schedule&.season ? next_schedule : nil
   end
 
   def previous
-    previous_schedule = self.class.where("day < ?", self.class.find(id).day).last
+    previous_schedule = self.class.where("day < ?", self.day).last
     self.edition == previous_schedule&.edition ? previous_schedule : nil
   end
 
   def previous_in_season
-    previous_schedule = self.class.where("day < ?", self.class.find(id).day).last
+    previous_schedule = self.class.where("day <= ? AND created_at < ?", self.day, self.created_at).order(:day).last
     self.season == previous_schedule&.season ? previous_schedule : nil
   end
 

--- a/app/views/competitions/_display_championship_calendar.html.erb
+++ b/app/views/competitions/_display_championship_calendar.html.erb
@@ -2,7 +2,7 @@
 
 <% edition.schedules.limit(3).each do |schedule| %>
     <div class="schedule-designation">
-      <%= "Journée " + schedule.designation.split("J")[1] %>
+      <%= "Journée " + schedule.designation %>
       <div class="info">
         <%= schedule.day.strftime("%d/%m/%Y") %>
       </div>

--- a/app/views/competitions/_display_championship_ranking.html.erb
+++ b/app/views/competitions/_display_championship_ranking.html.erb
@@ -1,7 +1,7 @@
 <table class="ranking">
   <tr>
     <th></th>
-    <th></th>
+    <th><%= edition.designation %></th>
     <th>Pts</th>
     <th>J</th>
     <th>G</th>
@@ -12,7 +12,7 @@
     <th>c.</th>
   </tr>
   <% rank = 1 %>
-  <% @ranking_datas.each do |id, team| %>
+  <% edition.computed_ranking_datas.each do |id, team| %>
     <tr data-controller="ranking-team-line" data-team-id="<%= team[:id] %>"%>
       <td class="rank"><%= "#{rank}. " %></td>
       <td class="bolder"><%= team[:name] %></td>

--- a/app/views/contestants/index.html.erb
+++ b/app/views/contestants/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Contestants for <%= @edition.competition.name + "/" + @edition.season.years %></h1>
+<h1>Contestants for <%= @edition.competition.name + "/" + @edition.season.years + "/" + @edition.designation %></h1>
 <%= simple_form_for [@edition, @new_contestant] do |f| %>
   <%= f.association :team, value_method: :id, label_method: :label_name %>
   <%= f.button :submit %>

--- a/app/views/editions/edit.html.erb
+++ b/app/views/editions/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>Update Edition</h1>
+<%= simple_form_for @edition do |f| %>
+  <%= f.association :season, value_method: :id, label_method: :years %>
+  <%= f.association :competition, value_method: :id, label_method: :name %>
+  <%= f.input :designation %>
+  <%= f.input :second_leg %>
+  <%= f.button :submit, class: "btn btn-warning" %>
+<% end -%>

--- a/app/views/editions/edit.html.erb
+++ b/app/views/editions/edit.html.erb
@@ -3,6 +3,7 @@
   <%= f.association :season, value_method: :id, label_method: :years %>
   <%= f.association :competition, value_method: :id, label_method: :name %>
   <%= f.input :designation %>
+	<%= f.input :letter %>
   <%= f.input :second_leg %>
   <%= f.button :submit, class: "btn btn-warning" %>
 <% end -%>

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -2,14 +2,17 @@
 <%= simple_form_for @edition do |f| %>
   <%= f.association :season, value_method: :id, label_method: :years %>
   <%= f.association :competition, value_method: :id, label_method: :name %>
-  <%= f.button :submit %>
+  <%= f.input :designation %>
+  <%= f.input :second_leg %>
+  <%= f.button :submit, class: "btn btn-warning" %>
 <% end -%>
 
 
 <ul>
   <% @editions.each do |edition| %>
     <li>
-      <%= link_to "(#{edition.season.id})" + edition.season.years + "/ (#{edition.competition.id})" + edition.competition.name, edition_path(edition) %>
+      <%= link_to "#{edition.designation}: (#{edition.season.id})" + edition.season.years + "/ (#{edition.competition.id})" + edition.competition.name, edition_path(edition) %>
+      <%= link_to "Edit", edit_edition_path(edition) %>
     </li>
   <% end %>
 </ul>

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -3,6 +3,7 @@
   <%= f.association :season, value_method: :id, label_method: :years %>
   <%= f.association :competition, value_method: :id, label_method: :name %>
   <%= f.input :designation %>
+  <%= f.input :letter %>
   <%= f.input :second_leg %>
   <%= f.button :submit, class: "btn btn-warning" %>
 <% end -%>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
-<% unless @edition %>
+<% unless @editions.present? %>
   <div class="top-page">
     <h3>
       La prochaine saison arrive...
@@ -7,7 +7,7 @@
 <% else %>
   <div class="top-page">
     <h3>
-      Saison <%= @edition.season.years %>
+      Saison <%= @editions.first.season.years %>
     </h3>
   </div>
   <hr>
@@ -41,7 +41,7 @@
   </div>
 
   <!-- Display championship ranking -->
-  <%= render "competitions/display_championship_ranking", edition: @edition %>
+  <%= render partial: "competitions/display_championship_ranking", collection: @editions, as: :edition %>
 
   <br>
 <% end %>

--- a/app/views/pages/season_show.html.erb
+++ b/app/views/pages/season_show.html.erb
@@ -1,6 +1,6 @@
 <div class="top-page">
   <h3>
-    Saison <%= @edition.season.years %>
+    Saison <%= @editions.first.season.years %>
   </h3>
 </div>
 <hr>
@@ -34,6 +34,6 @@
 </div>
 
 <!-- Display championship ranking -->
-<%= render "competitions/display_championship_ranking", edition: @edition %>
+<%= render partial: "competitions/display_championship_ranking", collection: @editions, as: :edition %>
 
 <br>

--- a/app/views/schedules/_show.html.erb
+++ b/app/views/schedules/_show.html.erb
@@ -5,7 +5,7 @@
   <% end %>
   <div class="schedule-designation">
     <% if schedule.edition.competition.kind == "championship" %>
-      <%= "Journée " + schedule.designation.split("J")[1] %>
+      <%= "Journée " + schedule.designation %>
     <% elsif schedule.edition.competition.kind == "cup" %>
       <%= "Cup " + schedule.designation %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     resources :competitions, only: [:index, :create, :show, :destroy]
     resources :teams, only: [:index, :create, :show]
     resources :stadiums, only: [:new, :create, :index, :edit, :update]
-    resources :editions, only: [:index, :create]
+    resources :editions, only: [:index, :create, :edit, :update]
     resources :editions, only: [:show] do
       resources :contestants, only: [:index, :create]
       resources :schedules, only: [:index, :create] do

--- a/db/migrate/20250105145547_create_rankings.rb
+++ b/db/migrate/20250105145547_create_rankings.rb
@@ -1,0 +1,10 @@
+class CreateRankings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :rankings do |t|
+      t.json :data
+      t.references :edition, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260223223815_add_second_leg_to_editions.rb
+++ b/db/migrate/20260223223815_add_second_leg_to_editions.rb
@@ -1,0 +1,9 @@
+class AddSecondLegToEditions < ActiveRecord::Migration[6.0]
+  def up
+    add_column :editions, :second_leg, :boolean, default: true
+  end
+
+  def down
+    remove_column :editions, :second_leg
+  end
+end

--- a/db/migrate/20260223232704_add_designation_to_editions.rb
+++ b/db/migrate/20260223232704_add_designation_to_editions.rb
@@ -1,0 +1,5 @@
+class AddDesignationToEditions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :editions, :designation, :string, default: "empty", null: false
+  end
+end

--- a/db/migrate/20260224005047_create_rankings.rb
+++ b/db/migrate/20260224005047_create_rankings.rb
@@ -3,6 +3,7 @@ class CreateRankings < ActiveRecord::Migration[6.0]
     create_table :rankings do |t|
       t.json :data
       t.references :edition, null: false, foreign_key: true
+      t.boolean :initial, default: false
 
       t.timestamps
     end

--- a/db/migrate/20260226223713_add_letter_to_editions.rb
+++ b/db/migrate/20260226223713_add_letter_to_editions.rb
@@ -1,0 +1,5 @@
+class AddLetterToEditions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :editions, :letter, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_04_094227) do
+ActiveRecord::Schema.define(version: 2026_02_26_223713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,9 @@ ActiveRecord::Schema.define(version: 2022_12_04_094227) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "second_legs_offset", default: 2
     t.integer "total_rounds"
+    t.boolean "second_leg", default: true
+    t.string "designation", default: "empty", null: false
+    t.string "letter"
     t.index ["competition_id"], name: "index_editions_on_competition_id"
     t.index ["season_id"], name: "index_editions_on_season_id"
   end
@@ -98,6 +101,15 @@ ActiveRecord::Schema.define(version: 2022_12_04_094227) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["schedule_id"], name: "index_games_on_schedule_id"
     t.index ["stadium_id"], name: "index_games_on_stadium_id"
+  end
+
+  create_table "rankings", force: :cascade do |t|
+    t.json "data"
+    t.bigint "edition_id", null: false
+    t.boolean "initial", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["edition_id"], name: "index_rankings_on_edition_id"
   end
 
   create_table "results", force: :cascade do |t|
@@ -190,6 +202,7 @@ ActiveRecord::Schema.define(version: 2022_12_04_094227) do
   add_foreign_key "editions", "seasons"
   add_foreign_key "games", "schedules"
   add_foreign_key "games", "stadiums"
+  add_foreign_key "rankings", "editions"
   add_foreign_key "results", "games"
   add_foreign_key "results", "teams"
   add_foreign_key "schedules", "editions"

--- a/lib/competitions/championship.rb
+++ b/lib/competitions/championship.rb
@@ -53,6 +53,7 @@ module Competitions
         }
       }
 
+      # TODO : I think sort_by render an array ! I need to keep full Hash to use fully Raking.data as Hash !! 
       ranking_datas.sort_by { |k,v| [-v[:points], -v[:goals_diff], -v[:goals_for]] }
     end
 


### PR DESCRIPTION
## Summary by Sourcery

Add persistent rankings for championship editions and support multiple editions per season with configurable metadata.

New Features:
- Persist championship rankings per edition and expose helpers to access current and initial rankings.
- Allow multiple editions of the same competition per season using an edition designation, letter, and second-leg flag.
- Add the ability to edit existing editions via new edit/update actions and views.

Bug Fixes:
- Ensure schedule navigation and game generation operate within the correct edition rather than across the whole season.
- Fix schedule date generation so subsequent rounds are based on the previous schedule date instead of the last global schedule.

Enhancements:
- Update home and season pages to display rankings and calendars for all championship editions in a season.
- Include edition designation in various views and headings to better distinguish parallel championships.
- Make second-leg game creation conditional based on the edition configuration and parameterize total rounds on this flag.