### PR TITLE
Ranking saving system finalisation

### DIFF
--- a/app/controllers/rankings_controller.rb
+++ b/app/controllers/rankings_controller.rb
@@ -1,0 +1,21 @@
+class RankingsController < ApplicationController
+  before_action :authenticate_user!
+
+  # app/controllers/rankings_controller.rb
+  def create_initial
+    # On utilise find_by pour la target pour avoir un nil si pas d'Edition selctionnée
+    # C'est un raccourci facile pour permettre de "supprimer" un ranking initial pour une édition
+    target_edition = Edition.find_by(id: params[:target_edition_id])
+    edition = Edition.find(params[:edition_id])
+    if edition
+      edition.rankings.create!(
+        data: target_edition ? target_edition.ranking_datas : {}, 
+        initial: true
+      )
+    end
+    redirect_to editions_path, notice: "Classement initial créé avec succès pour l'édition #{target_edition&.designation}."
+  rescue ActiveRecord::RecordNotFound
+    redirect_to request.referer, alert: "Édition non trouvée."
+  end
+
+end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -28,8 +28,8 @@ class ResultsController < ApplicationController
       @schedule = Schedule.find(params[:schedule_id])
       
       if @schedule.update(schedule_params)
-        # Vérifier si des results ont été modifiés
-        save_new_ranking_data
+        # Check if Results were updated in callback at SChedule model level after_update :check_results_update
+        # for ranking data saving if needed
         
         redirect_to enter_results_path(@schedule), notice: "Schedule #{@schedule.designation} has been updated!"
       else
@@ -67,15 +67,5 @@ class ResultsController < ApplicationController
               ]
             ]
           )
-  end
-
-  def save_new_ranking_data
-    logger.info "$$$$$$$ Handle result update $$$$$$$$"
-
-    # TODO TOCHECK : does result_changed? is enought to catch nested attributes ?
-    @schedule.edition.rankings.create!(
-      data: Competitions::Championship.new(edition: @schedule.edition).ranking_datas
-    )
-
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -14,20 +14,46 @@ class Edition < ApplicationRecord
     "#{self.season.years}/#{self.competition.kind}/#{self.competition.name}"
   end
 
-  def ranking
+  def ranking # => Ranking instance
+    # TODO : verif fonctionnement si pas de rankings ??
     rankings.where(initial: false).last
   end
 
-  def ranking_initial
+  def ranking_initial # => Ranking instance
     rankings.where(initial: true).last
+  end
+
+  def ranking_datas # => Ranking#data mapped for treatment
+    datas = 
+      ranking.present? ?
+          ranking.data :
+          Competitions::Championship.new(edition: self).ranking_datas
+
+    datas.to_a.map{|data| [data[0].to_i, data[1].deep_symbolize_keys] }.to_h
+  end
+
+  def ranking_initial_datas # => Ranking#data mapped for treatment
+    datas = 
+      ranking_initial.present? ?
+          ranking_initial.data :
+          {}
+
+    datas.to_a.map{|data| [data[0].to_i, data[1].deep_symbolize_keys] }.to_h
   end
 
   def computed_ranking_datas
     # TODO : ranking_data should compute last ranking data and last ranking_initial data
     
-    persisted_rankings = rankings
-    persisted_rankings.any? ?
-      persisted_rankings.last.data.deep_symbolize_keys :
-      Competitions::Championship.new(edition: self).ranking_datas
+    # d.to_a.map{|data| [data[0].to_i, data[1].deep_symbolize_keys] }.to_h
+    # pour convertir data from DB => { <int_ID> => {symbols as keys}, ...}
+    
+    filtered_initial_datas = 
+      ranking_initial_datas.present? ?
+        ranking_initial_datas.select { |key, _| ranking_datas.keys.include?(key) } :
+        {}
+
+    ranking_datas.deep_merge(filtered_initial_datas){ |key, val_a, val_b| 
+      [:id, :name].include?(key) ? val_a : val_a + val_b
+    }.sort_by { |k,v| [-v[:points], -v[:goals_diff], -v[:goals_for], v[:name]] }.to_h
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -24,7 +24,10 @@ class Edition < ApplicationRecord
 
   def computed_ranking_datas
     # TODO : ranking_data should compute last ranking data and last ranking_initial data
-    # ranking_datas = @edition.rankings.any? ? @edition.ranking.data : Competitions::Championship.new(edition: @edition).ranking_datas
-    Competitions::Championship.new(edition: self).ranking_datas
+    
+    persisted_rankings = rankings
+    persisted_rankings.any? ?
+      persisted_rankings.last.data.deep_symbolize_keys :
+      Competitions::Championship.new(edition: self).ranking_datas
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -2,7 +2,7 @@ class Game < ApplicationRecord
   belongs_to :schedule
   belongs_to :stadium, optional: true
 
-  has_many :results, dependent: :destroy
+  has_many :results, dependent: :destroy, inverse_of: :game
   accepts_nested_attributes_for :results
   default_scope { order(:id) }
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -8,6 +8,7 @@ class Schedule < ApplicationRecord
   # after_update :delay_all_season_schedules_day
 
   accepts_nested_attributes_for :games
+  after_update :check_results_update
 
 
   def next
@@ -94,6 +95,22 @@ class Schedule < ApplicationRecord
         schedule_iterator.update(day: schedule_iterator.day + 7)
       end
     end
+  end
+
+  def check_results_update
+    Rails.logger.info "######## check_results_update"
+    if games.flat_map(&:results).any?{|r| r.saved_change_to_attribute?(:mark) }
+      Rails.logger.info "######## Un ou plusieurs Result#mark ont été mis à jour pour le Schedule id:#{id}"
+      save_new_ranking_data
+    end
+  end
+
+  def save_new_ranking_data
+    logger.info "$$$$$$$ save_new_ranking_data $$$$$$$$"
+
+    edition.rankings.create!(
+      data: Competitions::Championship.new(edition: edition).ranking_datas
+    )
   end
 
 end

--- a/app/views/editions/index.html.erb
+++ b/app/views/editions/index.html.erb
@@ -14,6 +14,19 @@
     <li>
       <%= link_to "#{edition.designation}: (#{edition.season.id})" + edition.season.years + "/ (#{edition.competition.id})" + edition.competition.name, edition_path(edition) %>
       <%= link_to "Edit", edit_edition_path(edition) %>
+      <!-- Exemple dans app/views/editions/show.html.erb -->
+      <%= link_to "#",
+            class: "btn btn-secondary",
+            data: {
+              bs_toggle: "modal",
+              bs_target: "#chooseInitialForEditionModal_#{edition.id}"
+            } do %>
+        Ajouter Initial
+      <% end %>
+
+      <!-- Inclusion du partial pour la pop-up -->
+      <%= render 'rankings/choose_initial_for_edition', edition: edition %>
+
     </li>
   <% end %>
 </ul>

--- a/app/views/rankings/_choose_initial_for_edition.html.erb
+++ b/app/views/rankings/_choose_initial_for_edition.html.erb
@@ -1,0 +1,32 @@
+<div class="modal fade" id="chooseInitialForEditionModal_<%= edition.id %>" tabindex="-1" aria-labelledby="chooseInitialForEditionModalLabel_<%= edition.id %>" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content bg-dark text-light ">
+      <div class="modal-header">
+        <h5 class="modal-title" id="chooseInitialForEditionModalLabel_<%= edition.id %>">
+          <%= edition.season.years %> | <%= edition.designation %>
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Choisir un classement initial : </p>
+				<!-- Formulaire pour choisir une autre édition -->
+        <%= form_with(url: edition_rankings_create_initial_path(edition), method: :post, local: true) do |form| %>
+          <div class="mb-3">
+            <%= label_tag :target_edition_id, "Choisir une autre édition", class: "form-label" %>
+            <%= select_tag :target_edition_id,
+              options_from_collection_for_select(Edition.where.not(id: edition.id), :id, :designation),
+              prompt: "Sélectionnez une édition",
+              class: "form-select",
+              required: false %>
+          </div>
+          <div class="modal-footer">
+            <%= submit_tag "Valider", class: "btn btn-primary" %>
+          </div>
+        <% end %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,9 @@ Rails.application.routes.draw do
     get "results(/:id)", to: "results#enter_results", as: "enter_results"
     resources :articles
     resources :user_roles, only: [:index, :create, :destroy]
+    resources :editions do
+      post 'rankings/create_initial'
+    end
   end
 
   # Path related to registering preferences in client browser cookies

--- a/lib/competitions/championship.rb
+++ b/lib/competitions/championship.rb
@@ -54,7 +54,7 @@ module Competitions
       }
 
       # TODO : I think sort_by render an array ! I need to keep full Hash to use fully Raking.data as Hash !! 
-      ranking_datas.sort_by { |k,v| [-v[:points], -v[:goals_diff], -v[:goals_for]] }
+      ranking_datas.sort_by { |k,v| [-v[:points], -v[:goals_diff], -v[:goals_for]] }.to_h
     end
 
     private


### PR DESCRIPTION
1. Enabling ranking saving system
2. Edition#computed_ranking_datas is perfect
3. UI admin option to add ranking initial

## Summary by Sourcery

Finalize the ranking saving system by computing rankings from edition data, persisting updated rankings when results change, and enabling admins to define initial rankings via the UI.

New Features:
- Allow admins to set or clear an initial ranking for an edition by copying rankings from another edition via a modal dialog and new controller action.
- Expose edition-level helpers to access current and initial rankings and their processed data for ranking computations.

Bug Fixes:
- Ensure championship ranking data remains a hash after sorting by converting the sorted collection back to a hash.

Enhancements:
- Compute final ranking data by merging live rankings with optional initial rankings and applying tie-breaking rules on points and goal statistics.
- Move ranking persistence logic from the results controller into the schedule model callback to centralize updates when game results change.
- Associate results with their games using inverse_of to improve nested attributes handling in ActiveRecord.