### PR TITLE
Using next_in_edition instead of next

### DIFF
--- a/app/views/seasons/stats_stabis.html.erb
+++ b/app/views/seasons/stats_stabis.html.erb
@@ -33,7 +33,7 @@
     data[:percent] = data[:played].zero? ? 0 : (data[:stabi]/data[:played].to_f*100).round
   }
   stats.each{ |team_id, data|
-    next_schedule_games = @schedules.where("day < ?", Date.today).last.next.try(:games)
+    next_schedule_games = @schedules.where("day < ?", Date.today).last.next_in_edition.try(:games)
     if next_schedule_games
       next_game = next_schedule_games.find{|g| g.results.pluck(:team_id).include?(team_id)}
       next_opponent_id = next_game.results.where.not(team_id: team_id).first.team_id


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct upcoming game lookup in the stabis season stats view to use next_in_edition on schedules instead of next.