### PR TITLE
next_schedule_games.present?

### DIFF
--- a/app/views/seasons/stats_stabis.html.erb
+++ b/app/views/seasons/stats_stabis.html.erb
@@ -34,7 +34,7 @@
   }
   stats.each{ |team_id, data|
     next_schedule_games = @schedules.where("day < ?", Date.today).last.next_in_edition.try(:games)
-    if next_schedule_games
+    if next_schedule_games.present?
       next_game = next_schedule_games.find{|g| g.results.pluck(:team_id).include?(team_id)}
       next_opponent_id = next_game.results.where.not(team_id: team_id).first.team_id
       data[:percent_sum_for_next_game] = stats[next_opponent_id][:percent] + data[:percent]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent errors or incorrect calculations in the season stats view when the next scheduled games association exists but is empty.