### PR TITLE
Display schedule games by week

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -16,6 +16,53 @@ class SchedulesController < ApplicationController
     end
   end
 
+  def calendar_per_week
+    Rails.logger.info params
+    week = params[:week].to_i
+    year = params[:year].to_i
+    # On retrouve la Season courrante
+    season = week < 30 ? Season.find_by_years("#{year - 1}-#{year}"): Season.find_by_years("#{year}-#{year + 1}")
+    schedules_day = season.editions.flat_map(&:schedules).pluck(:day)
+    games_alternative_day = season.editions.flat_map(&:schedules).flat_map(&:games).pluck(:alternative_date).compact
+    range_date = ((schedules_day + games_alternative_day).sort).then {|array| (array.first.monday? ? array.first..array.last : array.first.prev_occurring(:monday))..array.last}
+    
+    @displayed_date = Date.commercial(year, week, 1)
+    loop do
+      Rails.logger.info ">>>> Essai semaine : " + @displayed_date.inspect
+      @week_calendar = Game.in_week_grouped_by_edition_and_schedule(@displayed_date.cweek, @displayed_date.cwyear)
+      #byebug
+
+      break if @week_calendar.present?
+      
+      if !range_date.include?(@displayed_date)
+        if @displayed_date > range_date.max
+
+          if params[:search_direction] == "futur"
+            @desable_direction = "futur"
+            
+            break
+          end
+          # On est hors du range et au dessus alors on doit chercher dans le past
+          params[:search_direction] == "past"
+        elsif @displayed_date < range_date.min
+
+          if params[:search_direction] == "past"
+            @desable_direction = "past"
+            
+            break
+          end
+          # sinon on recherche dans le futur
+          params[:search_direction] == "futur"
+        end
+      end
+      @displayed_date = params[:search_direction] == "past" ? @displayed_date - 7.days : @displayed_date + 7.days
+    end
+    respond_to do |format|
+      format.js {render layout: false}
+      format.html
+    end
+  end
+
   def create
     @edition = Edition.find(params[:edition_id])
     # Recieve first schedule date from the form

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -27,7 +27,7 @@ window.StimulusApplication = application
 console.log("Application Stimulus chargée");
 
 
-import { showSelectSchedule } from '../components/schedules'
+// import { showSelectSchedule } from '../components/schedules'
 import { markControlsHandler } from '../components/mark_controls_handler'
 import { forfeitBtnHandler } from '../components/forfeit_btn_handler'
 
@@ -73,18 +73,28 @@ document.addEventListener('turbolinks:load', () => {
   }
 
   if (window.location.pathname === "/" || window.location.pathname.includes("saisons/")) {
-    const activeSchedule = document.querySelector("#select-schedule > .active");
-    if (activeSchedule) {
-      activeSchedule.click();
-    } else {
-      // if last schedule is to far in past
-      const allSchedulesLinks = document.querySelectorAll("#select-schedule a");
-      const lastScheduleLink = allSchedulesLinks[allSchedulesLinks.length - 1];
-      lastScheduleLink.classList.add("active");
-      lastScheduleLink.click();
-    }
+    // const activeSchedule = document.querySelector("#select-schedule > .active");
+    // if (activeSchedule) {
+    //   activeSchedule.click();
+    // } else {
+    //   // if last schedule is to far in past
+    //   const allSchedulesLinks = document.querySelectorAll("#select-schedule a");
+    //   const lastScheduleLink = allSchedulesLinks[allSchedulesLinks.length - 1];
+    //   lastScheduleLink.classList.add("active");
+    //   lastScheduleLink.click();
+    // }
 
-    showSelectSchedule();
+    // showSelectSchedule();
+
+    const currentWeekLink =  document.querySelector("a#load-current-week");
+    console.log("Je passe là");
+    if (currentWeekLink) {
+      console.log(currentWeekLink);
+      console.log("J'ai trouvé le lien spécial show as_week");
+      currentWeekLink.click();
+    } else {
+      // TODO : gérer le début d'année car par défaut on va chercher dans le passé jusqu'à trouver une semaine avec des matches
+    }
   }
 
 });

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -9,6 +9,24 @@ class Game < ApplicationRecord
   # validates :stadium, uniqueness: { allow_blank: true, allow_nil: true }
   validates :schedule, presence: true
 
+  scope :in_week, ->(week_number, year) {
+    where(
+      "EXTRACT(week FROM COALESCE(games.alternative_date, schedules.day)) = ? " \
+      "AND EXTRACT(year FROM COALESCE(games.alternative_date, schedules.day)) = ?",
+      week_number, year
+    ).joins(:schedule)
+  }
+
+  # TODO : chat Mistral "select model by week..."
+  def self.in_week_grouped_by_edition_and_schedule(week_number, year)
+    in_week(week_number, year)
+      .includes(:schedule)
+      .group_by { |game| game.schedule.edition }
+      .transform_values do |games_in_edition|
+        games_in_edition.group_by { |game| game.schedule }
+      end
+  end
+
   def played?
     status == "played"
   end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -33,6 +33,12 @@
         <% active = "" %>
       <% end %>
     </div>
+    <%= link_to "Semaine à afficher",
+      calendar_per_week_schedules_path(year: (date_now + 4.days).cwyear, week: (date_now + 4.days).cweek, search_direction: :past), 
+      remote: true, 
+      class: "d-none",
+      id: "load-current-week"
+    %>
 
     <!-- Display active schedule -->
     <div id="active-schedule">

--- a/app/views/schedules/_show_as_week_calendar.html.erb
+++ b/app/views/schedules/_show_as_week_calendar.html.erb
@@ -1,0 +1,87 @@
+<div class="schedule-header">
+  <%= link_to calendar_per_week_schedules_path(year: (@displayed_date - 7.days).cwyear, week: (@displayed_date - 7.days).cweek, search_direction: :past ), remote: true, id: "search-direction-past" do %>
+    <%= fa_icon("chevron-circle-left", class: "change-schedule") %>
+  <% end %>
+  <div class="schedule-designation">
+    Semaine du <%= @displayed_date.strftime("%e %b %Y") %>
+    <div class="infomm">
+    </div>
+  </div>
+  <%= link_to calendar_per_week_schedules_path(year: (@displayed_date + 7.days).cwyear, week: (@displayed_date + 7.days).cweek, search_direction: :futur ), remote: true, id: "search-direction-futur" do %>
+    <%= fa_icon("chevron-circle-right", class: "change-schedule") %>
+  <% end %>
+</div>
+
+
+
+<% @week_calendar.each do |edition, schedules| %>
+  <% is_cup = edition.competition.kind == "cup" %>
+  <div class="bg-secondary bg-opacity-25 p-0 pb-1 mt-4 position-relative border border-dark border-1">
+    <span class="position-absolute top-0 end-0 bg-secondary text-white px-3 py-1 fs-6 fw-bold rounded-top border border-dark border-1" style="transform: translateY(-50%) translateX(1px);">
+      <%= edition.designation %>
+    </span>
+    
+    
+    <% schedules.each do |schedule, games| %>
+      <span class="bg-dark bg-opacity-75 text-white px-3 py-1 fs-6 fw-bold rounded-end " style="transform: translateY(-50%);">
+        <% if schedule.edition.competition.kind == "championship" %>
+            <%= "Journée " + schedule.designation %>
+          <% elsif schedule.edition.competition.kind == "cup" %>
+            <%= "Cup " + schedule.designation %>
+          <% else %>
+            <%= "Amical " + schedule.designation %>
+        <% end %>
+      </span>
+      
+      <div class="modern-matches">
+        <% games.sort_by(&:day).each do |game| %>
+          <div class="match-container" data-controller="games">
+            <!-- Div stade qui apparaitra -->
+            <div data-games-target="stadium" class="stadium-overlay">
+              <%= game.stadium&.name || '--' %>
+            </div>
+
+            <!-- Barre principale -->
+            <div data-games-target="mainContent" class="match-bar">
+              <div class="team team-left">
+                <span class="team-name-full" data-games-target="team" data-team-id="<%= game.results.first.team.id %>"><%= game.results.first.team.team_names.last.name %></span>
+                <span class="team-name-short"><%= game.results.first.team.team_names.last.name.first(5).upcase %></span>
+                <%= fa_icon("flag", class: "forfeit-flag", title: "Forfait") if game.results.first.forfeit %>
+              </div>
+
+              <div data-games-target="score" class="score-section">
+                <% if game.status == "delayed" %>
+                  <span class="status-text">Reporté</span>
+                <% elsif game.status == "canceled" %>
+                  <span class="status-text">Annulé</span>
+                <% elsif game.status == "played" %>
+                  <% draw = game.results.first.mark == game.results.last.mark %>
+                  <div class="score-display">
+                    <div class="score-number left">
+                      <% if draw && is_cup %><sub class="penalty">(<%= game.results.first.penalty_mark %>)</sub><% end %><%= game.results.first.mark %>
+                    </div>
+                    <div class="score-number right">
+                      <%= game.results.last.mark %><% if draw && is_cup %><sub class="penalty">(<%= game.results.last.penalty_mark %>)</sub><% end %>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+
+              <div class="team team-right">
+                <%= fa_icon("flag", class: "forfeit-flag", title: "Forfait") if game.results.last.forfeit %>
+                <span class="team-name-full" data-games-target="team" data-team-id="<%= game.results.last.team.id %>"><%= game.results.last.team.team_names.last.name %></span>
+                <span class="team-name-short"><%= game.results.last.team.team_names.last.name.first(4).upcase %></span>
+              </div>
+
+              <button data-games-target="button" data-action="click->games#toggle" class="stadium-btn">
+                <%= fa_icon("angle-double-left") %>
+              </button>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+

--- a/app/views/schedules/calendar_per_week.js.erb
+++ b/app/views/schedules/calendar_per_week.js.erb
@@ -1,0 +1,50 @@
+// Si besoin regarder schedules/show.js.erb : pas mal d'ancien code commenté !!
+
+console.log("Show schedule : Week Mode :)");
+
+<% if @desable_direction %>
+  // On désactive le lien ciblé
+  var targetLink = document.querySelector("a#search-direction-" + '<%= @desable_direction %>')
+  if (targetLink) {
+    targetLink.setAttribute("href", "#");
+    targetLink.querySelector("i").style.color = 'grey';
+  }
+<% else %>
+  document.querySelector("#active-schedule").innerHTML =
+    "<%= escape_javascript(render partial: 'schedules/show_as_week_calendar', locals: { week_calendar: @week_calendar, displayed_date: @displayed_date } ) %>";
+<% end %>
+
+var copyToClipboard = (event) => {
+  console.log("Action copy");
+  console.log(event.target);
+  let address = event.target.querySelector(".address-to-clipboard");
+  if (!address) {
+    address = event.target.parentElement.querySelector(".address-to-clipboard");
+  }
+  if (address) {
+    console.log(address.value);
+    address.select();
+    document.execCommand("copy");
+  }
+}
+
+var prepareActionsCopyToClipboard = () => {
+  const links = document.querySelectorAll(".link-copy-to-clipboard");
+  if (links) {
+    links.forEach( link => {
+      link.addEventListener("click", copyToClipboard);
+    });
+  }
+}
+
+if (document.readyState !== 'loading') {
+  console.log("Loaded");
+  prepareActionsCopyToClipboard();
+}
+
+if (window.StimulusApplication) {
+  requestAnimationFrame(() => {
+    window.StimulusApplication.stop()
+    window.StimulusApplication.start()
+  });
+}

--- a/app/views/schedules/show.js.erb
+++ b/app/views/schedules/show.js.erb
@@ -9,8 +9,11 @@ if(/iPhone|iPad|iPod/i.test(navigator.userAgent)){
   // for not mobile
   <% device = 'desktop' %>
 }
+// document.querySelector("#active-schedule").innerHTML =
+//  "<%= escape_javascript(render partial: 'schedules/show', locals: { schedule: @schedule, device: device } ) %>";
 document.querySelector("#active-schedule").innerHTML =
-  "<%= escape_javascript(render partial: 'schedules/show', locals: { schedule: @schedule, device: device } ) %>";
+  "<%= escape_javascript(render partial: 'schedules/show_as_week_calendar', locals: { week_calendar: @week_calendar } ) %>";
+
 
 
 /* START - THIS IS FOR THE SELECT ACTIVE SCHEDULE */

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,14 @@ Rails.application.routes.draw do
 
   root to: 'pages#home'
   get "saisons/:season_years", to: "pages#season_show", as: "season_show"
-  resources :schedules, only: [:show]
+  resources :schedules, only: [:show] do
+    collection do
+      get "calendar_per_week/:year/:week/:search_direction", 
+        to: "schedules#calendar_per_week", 
+        as: :calendar_per_week,
+        constraints: { search_direction: /past|futur/ }
+    end
+  end
 
   get "power", to: "pages#power"
   scope '/power' do


### PR DESCRIPTION
## Summary by Sourcery

Add support for displaying and navigating the game schedule by calendar week instead of only by individual schedule dates.

New Features:
- Introduce a weekly calendar view that groups games by edition and schedule for a given ISO week and year.
- Add a hidden home-page link that loads the current week’s schedule automatically on page load.
- Provide previous/next week navigation with server-side handling when no games exist in the requested week.

Enhancements:
- Change the schedules show JS response to render the new weekly calendar partial instead of the single-schedule view.
- Adjust homepage initialization JS to trigger loading of the current week view instead of auto-selecting an active schedule.